### PR TITLE
Reduce volume of data pushed with remote_write 

### DIFF
--- a/prometheus.template.yml
+++ b/prometheus.template.yml
@@ -1,7 +1,7 @@
 global:
-  scrape_interval: 5s
-  scrape_timeout: 5s
-  evaluation_interval: 5s
+  scrape_interval: 15s
+  scrape_timeout: 15s
+  evaluation_interval: 15s
 alerting:
   alertmanagers:
     - static_configs:
@@ -12,8 +12,8 @@ scrape_configs:
 #  <% _.forEach(nodes, (node) => { %>
 #  <% _.forEach(vchains, (vchain) => { %>
   - job_name: ${_.kebabCase(node.name)}-${vchain}
-    scrape_interval: 5s
-    scrape_timeout: 5s
+    scrape_interval: 15s
+    scrape_timeout: 15s
     metrics_path: /vchains/${vchain}/metrics.prometheus
     scheme: http
     static_configs:
@@ -21,7 +21,26 @@ scrape_configs:
         labels:
           machine: ${_.kebabCase(node.name)}
           vchain: ${vchain}
-          
+    metric_relabel_configs:
+      - source_labels: ['__name__']
+        regex: BlockSync.*
+        action: drop
+      - source_labels: ['__name__']
+        regex: ConsensusAlgo.Benchmark.*
+        action: drop
+      - source_labels: ['__name__']
+        regex: Ethereum.TimestampBlockFinder.*
+        action: drop
+      - source_labels: ['__name__']
+        regex: Gossip.OutgoingConnection.Queue.Usage.*
+        action: drop
+      - source_labels: ['__name__']
+        regex: Gossip.Topic.BenchmarkConsensus.*
+        action: drop
+      - source_labels: ['__name__']
+        regex: Processor.Native.*
+        action: drop
+
 #  <% }) %>
 #  <% }) %>
 # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write


### PR DESCRIPTION
Due to very high overuse charges by Hosted Grafana, we need to reduce the amount of data sent to them.

This is done by the following:

* Dropping some metrics after they are scraped from `/metrics.prometheus` but before they are pushed to Hosted Grafana
* Increasing scrape interval from `/metrics.prometheus`

This does not affect the data returned by accessing `/metrics` nor `/metrics.prometheus` end-points.